### PR TITLE
Improve sound performance

### DIFF
--- a/app/src/main/java/com/emerjbl/ultra8/chip8/sound/Synthesis.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/chip8/sound/Synthesis.kt
@@ -1,0 +1,24 @@
+package com.emerjbl.ultra8.chip8.sound
+
+import kotlin.math.PI
+import kotlin.math.sign
+
+fun wave(f: (Double) -> Double, freq: Float): FloatArray {
+    // Generate 1 cycle to loop
+    val samples = (SAMPLE_RATE / freq).toInt()
+    val out = FloatArray(samples)
+    val b = 2 * PI / SAMPLE_RATE
+    for (t in out.indices) {
+        val y = f(b * t.toDouble())
+        out[t] = y.toFloat()
+    }
+    return out
+}
+
+fun sin(freq: Int): (Double) -> Double = {
+    kotlin.math.sin(freq * it)
+}
+
+fun square(freq: Int): (Double) -> Double = {
+    sign(kotlin.math.sin(freq * it))
+}

--- a/app/src/main/java/com/emerjbl/ultra8/ui/viewmodel/Chip8ViewModel.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/viewmodel/Chip8ViewModel.kt
@@ -22,7 +22,7 @@ data class Program(val name: String, val id: Int)
 class Chip8ViewModel(application: Application) : AndroidViewModel(application) {
     private val gfx = SimpleGraphics()
     private val keys: Chip8Keys = Chip8Keys()
-    private val sound = AudioTrackSynthSound()
+    private val sound = AudioTrackSynthSound(viewModelScope)
     private val runner: Chip8Runner = Chip8ThreadRunner(keys, gfx, sound, TimeSource.Monotonic)
     val running: Flow<Boolean>
         get() = runner.running


### PR DESCRIPTION
For some reason, the AudioTrack is very slow on the main thread. On my
Pixel, calls to play often take ~60ms.

Moving it to a background thread prevents this from interrupting the emulator
thread.
