### PR TITLE
Various navigation fixes

### DIFF
--- a/app/src/main/java/com/emerjbl/ultra8/ui/screen/AppEntryPoint.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/screen/AppEntryPoint.kt
@@ -1,46 +1,87 @@
 package com.emerjbl.ultra8.ui.screen
 
-import android.content.Intent
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navDeepLink
+import com.emerjbl.ultra8.Ultra8Application
+import com.emerjbl.ultra8.ui.component.SideDrawer
 import com.emerjbl.ultra8.ui.theme.Ultra8Theme
-import kotlinx.serialization.Serializable
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
 
-@Serializable
-data class PlayGame(val programName: String)
-
-@Serializable
-data object LoadGame
 
 @Composable
 fun AppEntryPoint() {
     val navController = rememberNavController()
 
-    Ultra8Theme {
-        NavHost(navController, startDestination = PlayGame("breakout")) {
-            composable<PlayGame> {
-                PlayScreen(
-                    onSelectProgram = { navController.navigate(PlayGame(it)) }
-                )
-            }
+    val drawerState = rememberDrawerState(
+        initialValue = DrawerValue.Closed,
+    )
 
-            composable<LoadGame>(
-                deepLinks = listOf(
-                    navDeepLink {
-                        action = Intent.ACTION_VIEW
-                        mimeType = "*/*"
+    val scope = rememberCoroutineScope()
+
+    val programs =
+        (LocalContext.current.applicationContext as Ultra8Application)
+            .provider.programStore.programs.collectAsState()
+
+    val selectedProgram = remember { mutableStateOf("") }
+
+    val windowFocused = LocalWindowInfo.current.isWindowFocused
+
+    val gameShouldPause = remember { mutableStateOf(false) }
+
+    // Pass reset events from the navigation drawer down to gameplay children.
+    // This is one case where I feel like it's OK to break unidirectional dataflow.
+    // But I'll probably find a better approach eventually.
+    val resetEvents = remember { MutableSharedFlow<Unit>(extraBufferCapacity = 1) }
+
+    LifecycleResumeEffect(windowFocused) {
+        gameShouldPause.value = !windowFocused
+        onPauseOrDispose {
+            gameShouldPause.value = true
+        }
+    }
+
+    Ultra8Theme {
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            // Allow swipe/scrim tap to close, but don't try to open it with swipes when its not.
+            gesturesEnabled = drawerState.isOpen,
+            drawerContent = {
+                SideDrawer(
+                    drawerState,
+                    programs.value,
+                    selectedProgram.value,
+                    onProgramSelected = { program ->
+                        scope.launch {
+                            drawerState.close()
+                        }
+                        selectedProgram.value = program.name
+                        navController.navigate(PlayGame(program.name))
                     },
-                )
-            ) {
-                LoadScreen(onProgramLoaded = {
-                    navController.navigate(PlayGame(it)) {
-                        popUpTo(LoadGame) { inclusive = true }
+                    onReset = {
+                        scope.launch {
+                            drawerState.close()
+                        }
+                        resetEvents.tryEmit(Unit)
                     }
-                })
-            }
+                )
+            }) {
+            Ultra8NavHost(
+                navController,
+                gameShouldPause = gameShouldPause.value || drawerState.isOpen,
+                resetEvents = resetEvents,
+                onDrawerOpen = { scope.launch { drawerState.open() } }
+            )
         }
     }
 }

--- a/app/src/main/java/com/emerjbl/ultra8/ui/screen/Routes.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/screen/Routes.kt
@@ -1,0 +1,9 @@
+package com.emerjbl.ultra8.ui.screen
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlayGame(val programName: String)
+
+@Serializable
+data object LoadGame

--- a/app/src/main/java/com/emerjbl/ultra8/ui/screen/Ultra8NavHost.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/screen/Ultra8NavHost.kt
@@ -1,0 +1,40 @@
+package com.emerjbl.ultra8.ui.screen
+
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
+import androidx.navigation.toRoute
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun Ultra8NavHost(
+    navController: NavHostController,
+    gameShouldPause: Boolean,
+    resetEvents: Flow<Unit>,
+    onDrawerOpen: () -> Unit,
+) {
+    NavHost(navController, startDestination = PlayGame("breakout")) {
+        composable<PlayGame> { entry ->
+            PlayScreen(
+                programName = entry.toRoute<PlayGame>().programName,
+                paused = gameShouldPause,
+                resetEvents = resetEvents,
+                onDrawerOpen = onDrawerOpen,
+            )
+        }
+
+        composable<LoadGame>(
+            deepLinks = listOf(
+                navDeepLink {
+                    action = Intent.ACTION_VIEW
+                    mimeType = "*/*"
+                },
+            )
+        ) {
+            LoadScreen(onProgramLoaded = { navController.navigate(PlayGame(it)) })
+        }
+    }
+}

--- a/app/src/main/java/com/emerjbl/ultra8/ui/theme/Theme.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/theme/Theme.kt
@@ -69,9 +69,8 @@ fun Ultra8Theme(
         pixel3Color = colorScheme.primary,
     )
 
-
     CompositionLocalProvider(
-        LocalChip8ColorScheme provides chip8ColorScheme
+        LocalChip8ColorScheme provides chip8ColorScheme,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,


### PR DESCRIPTION
* Restructure so that ModalNavigationDrawer wraps most things
* Break more things into separate files
* Only create one PlayGameViewModel per game, per activity instance.

This mostly works really well, except that reset events go the wrong way. I
can work around this by passing a flow, but it kinda breaks unidirectional
flow.