### PR TITLE
Separate planes for scrolling/clean

### DIFF
--- a/app/src/androidTest/java/com/emerjbl/ultra8/DataStoreTest.kt
+++ b/app/src/androidTest/java/com/emerjbl/ultra8/DataStoreTest.kt
@@ -97,10 +97,10 @@ class DataStoreTest {
             i = 0x0242,
             pc = 0x0343,
             sp = 0x0545,
-            targetPlane = 0x03,
             gfx = FrameManager(),
         ).apply {
-            gfx.putSprite(10, 10, byteArrayOf(2, 3, 4, 56, 7, 7), 0, 5, 2)
+            gfx.targetPlane = 0x2
+            gfx.putSprite(10, 10, byteArrayOf(2, 3, 4, 56, 7, 7), 0, 5)
         }
 
         val STATE_2 = Chip8.State(
@@ -111,10 +111,10 @@ class DataStoreTest {
             i = 0x0342,
             pc = 0x0443,
             sp = 0x0845,
-            targetPlane = 0x02,
             gfx = FrameManager(),
         ).apply {
-            gfx.putSprite(15, 15, byteArrayOf(2, 3, 4, 56, 8, 8, 67, 12), 0, 4, 3)
+            gfx.targetPlane = 0x3
+            gfx.putSprite(15, 15, byteArrayOf(2, 3, 4, 56, 8, 8, 67, 12), 0, 4)
         }
     }
 }

--- a/app/src/main/java/com/emerjbl/ultra8/Ultra8Application.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/Ultra8Application.kt
@@ -29,8 +29,6 @@ class Ultra8Application : Application() {
                 .apply {
                     if (BuildConfig.DEBUG) {
                         fallbackToDestructiveMigration()
-                        fallbackToDestructiveMigrationOnDowngrade()
-
                     }
                 }
                 .addTypeConverter(IntArrayTypeConverter())

--- a/app/src/main/java/com/emerjbl/ultra8/chip8/graphics/FrameManager.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/chip8/graphics/FrameManager.kt
@@ -13,9 +13,9 @@ import java.util.concurrent.locks.ReentrantLock
  *
  * You can restore an instance with data as part of the resume sequence.
  */
-class FrameManager(hires: Boolean, frame: Frame) {
+class FrameManager(hires: Boolean, var targetPlane: Int, frame: Frame) {
     /** Create a fresh FrameManager. Starts in lo-res mode. */
-    constructor() : this(false, lowRes())
+    constructor() : this(false, 0x1, lowRes())
 
     private var frame: LockGuarded<Frame> = LockGuarded(ReentrantLock(), frame)
 
@@ -31,53 +31,73 @@ class FrameManager(hires: Boolean, frame: Frame) {
         }
 
     /** Create a complete copy of this manager. */
-    fun clone() = FrameManager(hires, frame.withLock { it.clone() })
+    fun clone() = FrameManager(hires, targetPlane, frame.withLock { it.clone() })
 
     /** Clear the screen. */
     fun clear() {
-        frame.withLock { it.data.fill(0) }
+        frame.withLock { frame ->
+            frame.operate(targetPlane) {
+                it.data.fill(0)
+            }
+        }
     }
 
     /** Scroll right by 4 pixels. (SCR instruction) */
     fun scrollRight() = frame.withLock { frame ->
-        for (row in 0 until frame.height) {
-            val rowStart = row * frame.width
-            val startIndex = row * frame.width
+        frame.operate(targetPlane) { it.scrollRight() }
+    }
+
+    private fun Plane.scrollRight() {
+        for (row in 0 until height) {
+            val rowStart = row * width
+            val startIndex = row * width
             val destinationOffset = rowStart + 4
-            val endIndex = rowStart + frame.width - 4
-            frame.data.copyInto(frame.data, destinationOffset, startIndex, endIndex)
-            frame.data.fill(0, 0, 4)
+            val endIndex = rowStart + width - 4
+            data.copyInto(data, destinationOffset, startIndex, endIndex)
+            data.fill(0, rowStart, rowStart + 4)
         }
     }
 
-    /** Scroll left by 4 pixels. (SCL instruction). */
+    /** Scroll left by 4 pixels. (SCL instruction) */
     fun scrollLeft() = frame.withLock { frame ->
-        for (row in 0 until frame.height) {
-            val rowStart = row * frame.width
+        frame.operate(targetPlane) { it.scrollLeft() }
+    }
+
+    private fun Plane.scrollLeft() {
+        for (row in 0 until height) {
+            val rowStart = row * width
             val startIndex = rowStart + 4
-            val destinationOffset = row * frame.width
-            val endIndex = rowStart + (frame.width)
-            frame.data.copyInto(frame.data, destinationOffset, startIndex, endIndex)
-            frame.data.fill(0, endIndex - 4, endIndex)
+            val destinationOffset = row * width
+            val endIndex = rowStart + width
+            data.copyInto(data, destinationOffset, startIndex, endIndex)
+            data.fill(0, endIndex - 4, endIndex)
         }
     }
 
-    /** Scroll down by N pixels (SCD instruction). */
+    /** Scroll up by N pixels (SCD instruction, Chip-XO). */
     fun scrollDown(n: Int) = frame.withLock { frame ->
-        val destinationOffset = n * frame.width
+        frame.operate(targetPlane) { it.scrollDown(n) }
+    }
+
+    private fun Plane.scrollDown(n: Int) {
+        val destinationOffset = n * width
         val startIndex = 0
-        val endIndex = (frame.height - n) * frame.width
-        frame.data.copyInto(frame.data, destinationOffset, startIndex, endIndex)
-        frame.data.fill(0, 0, n * frame.width)
+        val endIndex = (height - n) * width
+        data.copyInto(data, destinationOffset, startIndex, endIndex)
+        data.fill(0, 0, n * width)
     }
 
     /** Scroll up by N pixels (SCU instruction, Chip-XO). */
     fun scrollUp(n: Int) = frame.withLock { frame ->
+        frame.operate(targetPlane) { it.scrollUp(n) }
+    }
+
+    private fun Plane.scrollUp(n: Int) {
         val destinationOffset = 0
-        val startIndex = n * frame.width
-        val endIndex = frame.width * frame.height
-        frame.data.copyInto(frame.data, destinationOffset, startIndex, endIndex)
-        frame.data.fill(0, 0, n * frame.width)
+        val startIndex = n * width
+        val endIndex = width * height
+        data.copyInto(data, destinationOffset, startIndex, endIndex)
+        data.fill(0, (height - n) * width, height * width)
     }
 
     /** DRW instruction implementation. */
@@ -87,56 +107,49 @@ class FrameManager(hires: Boolean, frame: Frame) {
         /** Y-coordinate in Chip8 pixels for the top-left. */
         yBase: Int,
         /** The data that provides the sprite data. */
-        data: ByteArray,
+        src: ByteArray,
         /** The offset into the data. */
         offset: Int,
         /** The number of lines of sprite data. */
         linesIn: Int,
-        /**
-         * The plane(s) to draw to.
-         *
-         * Remember that drawing to plane 3 draws twice as much data.
-         **/
-        planes: Int,
     ): Boolean {
-        val plane3Offset = if (linesIn == 0) 32 else linesIn
-        return when (planes) {
-            1 -> putPlaneSprite(xBase, yBase, data, offset, linesIn, 1)
-            2 -> putPlaneSprite(xBase, yBase, data, offset, linesIn, 2)
-            // Note: Use of non-short-circuiting `or` here, so both plans are always drawn.
-            3 -> putPlaneSprite(xBase, yBase, data, offset, linesIn, 1) or
-                    putPlaneSprite(xBase, yBase, data, offset + plane3Offset, linesIn, 2)
+        val plane3Offset = offset + if (linesIn == 0) 32 else linesIn
+        return frame.withLock { frame ->
+            when (targetPlane) {
+                1 -> frame.plane1.putSprite(xBase, yBase, src, offset, linesIn)
+                2 -> frame.plane2.putSprite(xBase, yBase, src, offset, linesIn)
+                // Note: Use of non-short-circuiting `or` here, so both plans are always drawn.
+                3 -> frame.plane1.putSprite(xBase, yBase, src, offset, linesIn) or
+                        frame.plane2.putSprite(xBase, yBase, src, plane3Offset, linesIn)
 
-            else -> false
+                else -> false
+            }
         }
     }
 
-    private fun putPlaneSprite(
+    private fun Plane.putSprite(
         xBase: Int,
         yBase: Int,
-        data: ByteArray,
+        src: ByteArray,
         offset: Int,
         linesIn: Int,
-        plane: Int,
     ): Boolean {
         var unset = false
         val bytesPerRow = if (linesIn == 0) 2 else 1
         val lines = if (linesIn == 0) 16 else linesIn
 
-        frame.withLock { frame ->
-            for (yOffset in 0 until lines) {
-                for (rowByte in 0 until bytesPerRow) {
-                    var row = data[offset + (yOffset * bytesPerRow) + rowByte].toInt()
-                    val y = ((yBase + yOffset) and frame.height - 1)
-                    for (xOffset in 0..7) {
-                        if ((row and 0x80) != 0) {
-                            val x = ((xBase + xOffset + rowByte * 8) and (frame.width - 1))
-                            val i = y * frame.width + x
-                            unset = unset || (frame.data[i] and plane != 0)
-                            frame.data[i] = frame.data[i] xor plane
-                        }
-                        row = row shl 1
+        for (yOffset in 0 until lines) {
+            for (rowByte in 0 until bytesPerRow) {
+                var row = src[offset + (yOffset * bytesPerRow) + rowByte].toInt()
+                val y = ((yBase + yOffset) and height - 1)
+                for (xOffset in 0..7) {
+                    if ((row and 0x80) != 0) {
+                        val x = ((xBase + xOffset + rowByte * 8) and (width - 1))
+                        val i = y * width + x
+                        unset = unset || (data[i].toInt() == 1)
+                        data[i] = (data[i].toInt() xor 1).toByte()
                     }
+                    row = row shl 1
                 }
             }
         }
@@ -152,7 +165,8 @@ class FrameManager(hires: Boolean, frame: Frame) {
      **/
     fun nextFrame(lastFrame: Frame?): Frame = frame.withLock { frame ->
         if (lastFrame?.height == frame.height && lastFrame.width == frame.width) {
-            frame.data.copyInto(lastFrame.data)
+            frame.plane1.data.copyInto(lastFrame.plane1.data)
+            frame.plane2.data.copyInto(lastFrame.plane2.data)
             lastFrame
         } else {
             frame.clone()
@@ -170,15 +184,30 @@ class FrameManager(hires: Boolean, frame: Frame) {
         /** The height of the screen in Chip8 pixels. */
         val height: Int,
 
-        /** The packing pixel data. */
-        val data: IntArray
+        /** The backing pixel data. */
+        plane1: ByteArray = ByteArray(width * height),
+        plane2: ByteArray = ByteArray(width * height)
     ) {
-        /** Create a new empty frame. */
-        constructor(width: Int, height: Int) : this(width, height, IntArray(width * height))
+        val plane1 = Plane(width, height, plane1)
+        val plane2 = Plane(width, height, plane2)
+
+        inline fun operate(targetPlane: Int, action: (Plane) -> Unit) {
+            when (targetPlane) {
+                1 -> action(plane1)
+                2 -> action(plane2)
+                3 -> {
+                    action(plane1)
+                    action(plane2)
+                }
+            }
+
+        }
 
         /** Provide a complete copy of this frame, separate from this instance. */
-        fun clone(): Frame = Frame(width, height, data.clone())
+        fun clone(): Frame = Frame(width, height, plane1.data.clone(), plane2.data.clone())
     }
+
+    class Plane(val width: Int, val height: Int, val data: ByteArray)
 
 
     companion object {

--- a/app/src/main/java/com/emerjbl/ultra8/chip8/machine/Chip8.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/chip8/machine/Chip8.kt
@@ -50,8 +50,6 @@ class Chip8(
         var sp: Int = 0,
         /** Program counter. */
         var pc: Int = EXEC_START,
-        /** Chip-XO target plane for drawing (0-3). */
-        var targetPlane: Int = 0x1,
 
         /** Graphics buffer is an important part of state, too. */
         val gfx: FrameManager = FrameManager(),
@@ -74,7 +72,6 @@ class Chip8(
             val i: Int get() = state.i
             val sp: Int get() = state.sp
             val pc: Int get() = state.pc
-            val targetPlane: Int get() = state.targetPlane
             val halted: Halt? get() = state.halted
 
             /** Create a deep copy of the entire state. */
@@ -86,7 +83,6 @@ class Chip8(
                 i,
                 sp,
                 pc,
-                targetPlane,
                 state.gfx.clone(),
                 state.halted
             )
@@ -254,7 +250,7 @@ class Chip8(
                 0xB0 -> pc = v[0] + nnn
                 0xC0 -> v[x] = random.nextInt(0xFF) and b2
                 0xD0 -> v[0xF] =
-                    if (gfx.putSprite(v[x], v[y], mem, i, subOp, targetPlane)) 1 else 0
+                    if (gfx.putSprite(v[x], v[y], mem, i, subOp)) 1 else 0
 
                 0xE0 -> when (b2) {
                     0x9E -> if (keys.pressed(v[x])) skipNextInstruction()
@@ -273,7 +269,7 @@ class Chip8(
                         if (inst.x > 3 || inst.x < 0) {
                             return Halt.InvalidBitPlane(pc - 2, x)
                         }
-                        targetPlane = inst.x
+                        gfx.targetPlane = inst.x
                     }
 
                     0x02 -> {

--- a/app/src/main/java/com/emerjbl/ultra8/data/Ultra8Database.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/data/Ultra8Database.kt
@@ -3,7 +3,7 @@ package com.emerjbl.ultra8.data
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [Chip8ProgramState::class], version = 1)
+@Database(entities = [Chip8ProgramState::class], version = 2)
 abstract class Ultra8Database : RoomDatabase() {
     abstract fun chip8StateDao(): Chip8ProgramStateDao
 }

--- a/app/src/main/java/com/emerjbl/ultra8/ui/helpers/FrameHolder.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/helpers/FrameHolder.kt
@@ -63,9 +63,10 @@ class FrameHolder(
     /** Update this frame's data for the provided `frameDiff`. */
     fun update(frame: FrameManager.Frame, frameDiff: Int, frameConfig: FrameConfig) {
         var currentlyFading = 0
-        for (i in frame.data.indices) {
+        for (i in frame.plane1.data.indices) {
+            val pixel = frame.plane1.data[i].toInt() or (frame.plane2.data[i].toInt() shl 1);
             // If the pixel is being unset, start its fade timer
-            if (frame.data[i] == 0 && pixelData[i].alpha == 0xFF) {
+            if (pixel == 0 && pixelData[i].alpha == 0xFF) {
                 fadeTimes[i] = frameConfig.fadeMillisInt
             }
 
@@ -83,12 +84,12 @@ class FrameHolder(
             }
 
             // Set Pixel
-            when (frame.data[i]) {
+            when (pixel) {
                 1 -> pixelData[i] = frameConfig.colorInt
                 2 -> pixelData[i] = frameConfig.color2Int
                 3 -> pixelData[i] = frameConfig.color3Int
             }
-            if (frame.data[i] != 0) fadeTimes[i] = 0
+            if (pixel != 0) fadeTimes[i] = 0
         }
 
         fadingPixels = currentlyFading
@@ -116,12 +117,12 @@ fun FrameHolder?.next(
     frameConfig: FrameConfig
 ): FrameHolder {
     val fadeTimes = this?.fadeTimes
-        ?.takeIf { it.size == frame.data.size }
-        ?: IntArray(frame.data.size)
+        ?.takeIf { it.size == frame.plane1.data.size }
+        ?: IntArray(frame.plane1.data.size)
 
     val pixelData = this?.pixelData
-        ?.takeIf { it.size == frame.data.size }
-        ?: IntArray(frame.data.size)
+        ?.takeIf { it.size == frame.plane1.data.size }
+        ?: IntArray(frame.plane1.data.size)
 
     // Add some space for filter blur to extend into.
     val bitmapWidth = frame.width + 2 * FILTER_PADDING_PX

--- a/testutil/src/main/java/com/emerjbl/ultra8/testutil/Assertion.kt
+++ b/testutil/src/main/java/com/emerjbl/ultra8/testutil/Assertion.kt
@@ -21,6 +21,13 @@ fun Assertion.Builder<Chip8.State>.contentEquals(other: Chip8.State): Assertion.
             .isEqualTo(other.sp)
         strikt.api.expectThat(subject.pc).describedAs("PC: %s")
             .isEqualTo(other.pc)
-        strikt.api.expectThat(subject.targetPlane).describedAs("TargetPlane: %s")
-            .isEqualTo(other.targetPlane)
+        strikt.api.expectThat(subject.gfx.targetPlane).describedAs("TargetPlane: %s")
+            .isEqualTo(other.gfx.targetPlane)
+        val subjectFrame = subject.gfx.nextFrame(null)
+        val otherFrame = other.gfx.nextFrame(null)
+        strikt.api.expectThat(subjectFrame.width).isEqualTo(otherFrame.width)
+        strikt.api.expectThat(subjectFrame.height).isEqualTo(otherFrame.height)
+        strikt.api.expectThat(subjectFrame.plane1.data).contentEquals(otherFrame.plane1.data)
+        strikt.api.expectThat(subjectFrame.plane2.data).contentEquals(otherFrame.plane2.data)
+
     }


### PR DESCRIPTION
* Manage planes 1 and 2 separately so they can be scrolled easily
  independently as specified.
* SCU and SCR edge fills
* Switch to storing bytes to save a bit of space.
* Fix database migration