### PR TITLE
Fix some performance issues

### DIFF
--- a/app/src/main/java/com/emerjbl/ultra8/chip8/machine/Chip8Timer.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/chip8/machine/Chip8Timer.kt
@@ -13,7 +13,12 @@ class Chip8Timer(private val timeSource: TimeSource) {
     var value: Int
         get() {
             // If timer is still active, negative time has elapsed.
-            val elapsed = maxOf(Duration.ZERO, -timerActiveUntil.elapsedNow())
+            // Don't use minOf/mmaxOf, they cause boxing.
+            val elapsed = if (timerActiveUntil.hasPassedNow()) {
+                Duration.ZERO
+            } else {
+                -timerActiveUntil.elapsedNow()
+            }
             // Ceil because we don't decrement tick until the entire tick time
             // has passed; toInt would decrement tick right away.
             return ceil(elapsed / TICK_TIME).toInt()

--- a/app/src/main/java/com/emerjbl/ultra8/ui/content/Gameplay.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/content/Gameplay.kt
@@ -38,7 +38,7 @@ fun PortraitGameplay(
         Box(contentAlignment = Alignment.BottomCenter) {
             Graphics(
                 running,
-                frame = frame
+                frame = frame,
             )
             if (halt != null) {
                 Text(halt.toString(), style = MaterialTheme.typography.labelSmall)

--- a/app/src/main/java/com/emerjbl/ultra8/ui/helpers/FrameHolder.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/helpers/FrameHolder.kt
@@ -102,6 +102,7 @@ class FrameHolder(
             frame.width,
             frame.height
         )
+        bitmap.prepareToDraw()
     }
 }
 

--- a/app/src/main/java/com/emerjbl/ultra8/ui/screen/PlayScreen.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/screen/PlayScreen.kt
@@ -57,7 +57,6 @@ fun PlayScreen(
         }
     }
 
-    val running by viewModel.running.collectAsState(initial = false)
     val frame by viewModel.frames.collectAsState()
     val halt by viewModel.halted.collectAsState()
 
@@ -88,7 +87,7 @@ fun PlayScreen(
             if (!isLandscape()) BottomBar(cyclesPerTick = viewModel.cyclesPerTick)
         }
     ) { innerPadding ->
-        if (running) {
+        if (gameShouldRun) {
             focusRequester.requestFocus()
         }
 
@@ -96,7 +95,7 @@ fun PlayScreen(
         if (isLandscape()) {
             LandscapeGameplay(
                 innerPadding,
-                running,
+                gameShouldRun && halt == null,
                 frame,
                 viewModel.cyclesPerTick,
                 viewModel::keyDown,
@@ -104,7 +103,7 @@ fun PlayScreen(
             )
         } else {
             PortraitGameplay(
-                running,
+                gameShouldRun && halt == null,
                 frame,
                 viewModel::keyDown,
                 viewModel::keyUp,


### PR DESCRIPTION
* minOf/maxOf cause boxing on Durations, and that gets hit a lot in some
  games due to the timer logic.
* The render loop was not being properly stopped on game halt.
* Call prepareToDraw on bitmap after frame updates.
  * See: https://developer.android.com/develop/ui/compose/graphics/images/optimization#preparetodraw
* Make sure to stop render loops on pause