### PR TITLE
Restore subtraction behavior.

### DIFF
--- a/app/src/main/java/com/emerjbl/ultra8/chip8/machine/Chip8.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/chip8/machine/Chip8.kt
@@ -251,7 +251,7 @@ class Chip8(
                     0x05 -> {
                         val result = v[x] - v[y]
                         v[x] = result and 0xFF
-                        v[0xF] = if (result > 0) 1 else 0
+                        v[0xF] = if (result >= 0) 1 else 0
                     }
 
                     0x06 -> {


### PR DESCRIPTION
I don't know why the test suite was failing before. But in fact, it
passes either way, no matter what this value is. But >= is the correct
value (ant doesn't walk without it).
