### PR TITLE
Don't save last program state

### DIFF
--- a/app/src/main/java/com/emerjbl/ultra8/Ultra8Application.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/Ultra8Application.kt
@@ -1,10 +1,6 @@
 package com.emerjbl.ultra8
 
 import android.app.Application
-import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
 import androidx.room.RoomDatabase
 import com.emerjbl.ultra8.data.CatalogDatabase
 import com.emerjbl.ultra8.data.CatalogStore
@@ -19,8 +15,6 @@ interface Provider {
     val userDb: RoomDatabase
     val catalogDb: RoomDatabase
 }
-
-val Context.preferences: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 class Ultra8Application : Application() {
     val provider = object : Provider {

--- a/app/src/main/java/com/emerjbl/ultra8/data/ProgramStore.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/data/ProgramStore.kt
@@ -3,18 +3,14 @@ package com.emerjbl.ultra8.data
 import android.content.Context
 import android.net.Uri
 import android.provider.MediaStore.MediaColumns
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Upsert
-import com.emerjbl.ultra8.preferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 /** A single program entry. */
@@ -62,18 +58,6 @@ class ProgramStore(
 ) {
     fun programsFlow(): Flow<List<Program>> = programDao.allFlow()
 
-    val selectedProgram: Flow<SelectedProgram> = context.preferences.data.map {
-        it[SELECTED_PROGRAM_KEY]
-            ?.let { SelectedProgram.Program(it) }
-            ?: SelectedProgram.None
-    }
-
-    suspend fun setSelectedProgram(name: String) {
-        context.preferences.edit {
-            it[SELECTED_PROGRAM_KEY] = name
-        }
-    }
-
     suspend fun add(program: Program) {
         programDao.add(program)
     }
@@ -109,9 +93,4 @@ class ProgramStore(
         programDao.updateCyclesPerTick(name, cyclesPerTick)
 
     suspend fun remove(name: String) = programDao.remove(Program(name, 0))
-
-    companion object {
-        private val SELECTED_PROGRAM_KEY = stringPreferencesKey("lastProgram")
-        private const val DEFAULT_PROGRAM_NAME = "breakout"
-    }
 }

--- a/app/src/main/java/com/emerjbl/ultra8/ui/gameplay/PlayGameViewModel.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/gameplay/PlayGameViewModel.kt
@@ -104,7 +104,6 @@ class PlayGameViewModel(
             // TODO: See if we can improve this.
             frames.value = machine.nextFrame(null)
 
-            programStore.setSelectedProgram(programName)
             while (isActive) {
                 if (!running.value || machine.stateView.halted != null) {
                     Log.i("Chip8", "$programName paused at ${machine.stateView.pc.toHexString()}")
@@ -117,7 +116,6 @@ class PlayGameViewModel(
                     // TODO: See if we can improve this.
                     frames.value = machine.nextFrame(null)
                     Log.i("Chip8", "$programName resumed at ${machine.stateView.pc.toHexString()}")
-                    programStore.setSelectedProgram(programName)
                 }
                 val instructionTime = measureTime {
                     val result = machine.tick(cyclesPerTick.value)

--- a/app/src/main/java/com/emerjbl/ultra8/ui/loading/InitialLoadScreen.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/loading/InitialLoadScreen.kt
@@ -3,7 +3,6 @@ package com.emerjbl.ultra8.ui.loading
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.emerjbl.ultra8.data.SelectedProgram
 import com.emerjbl.ultra8.ui.gameplay.PlayScreen
 import kotlinx.coroutines.flow.flowOf
 
@@ -11,23 +10,16 @@ import kotlinx.coroutines.flow.flowOf
 fun InitialLoadScreen(
     onDrawerOpen: () -> Unit,
     onCatalog: () -> Unit,
-    onReady: (String) -> Unit,
 ) {
     val viewModel = viewModel<InitialLoadViewModel>(factory = InitialLoadViewModel.Factory)
-    val selectedProgram = viewModel.selectedProgram.collectAsState(SelectedProgram.Loading).value
-    println("SELECTED PROGRAM: $selectedProgram")
-    when (selectedProgram) {
-        is SelectedProgram.None -> onCatalog()
-        is SelectedProgram.Program -> onReady(selectedProgram.programName)
-        else -> Unit
-    }
-    val title = when (selectedProgram) {
-        is SelectedProgram.Loading -> "Loading..."
-        is SelectedProgram.None -> "<- Choose a game"
-        is SelectedProgram.Program -> selectedProgram.programName
+    val programCount = viewModel.programs.collectAsState(null).value
+    when {
+        programCount == null -> Unit
+        programCount.size == 0 -> onCatalog()
+        else -> onDrawerOpen()
     }
 
     // Just show a blank play screen while loading.
-    PlayScreen("", false, flowOf(), onDrawerOpen, title)
+    PlayScreen("", false, flowOf(), onDrawerOpen, "<- Choose a game")
 
 }

--- a/app/src/main/java/com/emerjbl/ultra8/ui/loading/InitialLoadViewModel.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/loading/InitialLoadViewModel.kt
@@ -3,14 +3,12 @@ package com.emerjbl.ultra8.ui.loading
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.emerjbl.ultra8.data.ProgramStore
-import com.emerjbl.ultra8.data.SelectedProgram
 import com.emerjbl.ultra8.util.viewModelFactory
-import kotlinx.coroutines.flow.Flow
 
 class InitialLoadViewModel(
     programStore: ProgramStore,
 ) : ViewModel() {
-    val selectedProgram: Flow<SelectedProgram> = programStore.selectedProgram
+    val programs = programStore.programsFlow()
 
     companion object {
         val Factory: ViewModelProvider.Factory = viewModelFactory {

--- a/app/src/main/java/com/emerjbl/ultra8/ui/navigation/AppEntryPoint.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/navigation/AppEntryPoint.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
-import com.emerjbl.ultra8.data.SelectedProgram
 import com.emerjbl.ultra8.ui.theme.Ultra8Theme
 import com.emerjbl.ultra8.util.matchesRoute
 import kotlinx.coroutines.launch
@@ -27,8 +26,8 @@ fun AppEntryPoint() {
 
     val topLevelViewModel = viewModel<TopLevelViewModel>(factory = TopLevelViewModel.Factory)
     val programs = topLevelViewModel.programs.collectAsState(emptyList())
-    val selectedProgram =
-        topLevelViewModel.selectedProgram.collectAsState(SelectedProgram.Loading).value
+
+    val selectedProgram = remember { mutableStateOf("") }
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
 
@@ -52,7 +51,7 @@ fun AppEntryPoint() {
                 SideDrawer(
                     drawerState,
                     programs.value,
-                    selectedProgram,
+                    selectedProgram.value,
                     onProgramSelected = { program ->
                         scope.launch { drawerState.close() }
                         val route = PlayGame(program.name)
@@ -80,6 +79,7 @@ fun AppEntryPoint() {
                 gameShouldRun = gameShouldRun.value,
                 resetEvents = topLevelViewModel.resetEvents,
                 onDrawerOpen = { scope.launch { drawerState.open() } },
+                onActiveProgram = { selectedProgram.value = it }
             )
         }
     }

--- a/app/src/main/java/com/emerjbl/ultra8/ui/navigation/SideDrawer.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/navigation/SideDrawer.kt
@@ -21,13 +21,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.emerjbl.ultra8.data.Program
-import com.emerjbl.ultra8.data.SelectedProgram
 
 @Composable
 fun SideDrawer(
     drawerState: DrawerState,
     programs: List<Program>,
-    selectedProgram: SelectedProgram,
+    selectedProgram: String,
     onProgramSelected: (Program) -> Unit,
     onReset: () -> Unit,
     onCatalog: () -> Unit,
@@ -93,7 +92,7 @@ fun SideDrawer(
                             }
                         }
                     },
-                    selected = SelectedProgram.Program(program.name) == selectedProgram
+                    selected = program.name == selectedProgram
                 )
             }
         }

--- a/app/src/main/java/com/emerjbl/ultra8/ui/navigation/TopLevelViewModel.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/navigation/TopLevelViewModel.kt
@@ -20,8 +20,6 @@ class TopLevelViewModel(
     // But I'll probably find a better approach eventually.
     val resetEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    val selectedProgram = programStore.selectedProgram
-
     fun removeProgram(name: String) {
         viewModelScope.launch {
             programStore.remove(name)

--- a/app/src/main/java/com/emerjbl/ultra8/ui/navigation/Ultra8NavHost.kt
+++ b/app/src/main/java/com/emerjbl/ultra8/ui/navigation/Ultra8NavHost.kt
@@ -21,6 +21,7 @@ fun Ultra8NavHost(
     gameShouldRun: Boolean,
     resetEvents: Flow<Unit>,
     onDrawerOpen: () -> Unit,
+    onActiveProgram: (String) -> Unit,
 ) {
     NavHost(navController, startDestination = InitialLoad) {
         composable<InitialLoad> {
@@ -35,15 +36,7 @@ fun Ultra8NavHost(
                         }
                     }
                 },
-                onReady = {
-                    navController.navigate(PlayGame(it)) {
-                        // https://issuetracker.google.com/issues/370694831
-                        @SuppressLint("RestrictedApi")
-                        popUpTo(InitialLoad) {
-                            inclusive = true
-                        }
-                    }
-                })
+            )
         }
         composable<Catalog> {
             CatalogScreen(
@@ -66,6 +59,7 @@ fun Ultra8NavHost(
             // Prevent game running when view is animating away.
             val gameShouldRun =
                 gameShouldRun && entry.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+            onActiveProgram(routeProgram)
             PlayScreen(
                 programName = routeProgram,
                 gameShouldRun = gameShouldRun,


### PR DESCRIPTION
If the process is killed by Android, the navigation component already
remembers and restores the whole backstack.

If the process is killed by the user, we can assume they want to "reset"
things, so we shouldn't try to restore things.
